### PR TITLE
Allow parameters to be passed in on register.

### DIFF
--- a/lib/morphine.rb
+++ b/lib/morphine.rb
@@ -11,8 +11,8 @@ module Morphine
 
   module ClassMethods
     def register(name, &block)
-      define_method name do
-        dependencies[name] ||= instance_eval(&block)
+      define_method name do |*args|
+        dependencies[name] ||= instance_exec(*args,&block)
       end
 
       define_method "#{name}=" do |service|

--- a/spec/morphine_spec.rb
+++ b/spec/morphine_spec.rb
@@ -31,5 +31,10 @@ describe Morphine do
       container.client = 'new client'
       container.client.should eq('new client')
     end
+
+    it 'passes arguments through to the block' do
+      Container().register(:pass_through) { |argument| argument }
+      container.pass_through(:a).should == :a
+    end
   end
 end


### PR DESCRIPTION
Allows parameters to be passed into register. I'm not sure this is strictly necessary for a DI framework but I've found it useful, allowing things like this...

```
class Selector
  include Morphine

  register(:type) { |id| TypeRepository.fetch(id) }
end
```

Thoughts?
